### PR TITLE
Refactor CLI and Weblio fetching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaya-kzt/dicto
 
-go 1.19
+go 1.25.5
 
 require (
 	github.com/PuerkitoBio/goquery v1.4.1

--- a/main.go
+++ b/main.go
@@ -1,31 +1,48 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 )
 
-var (
-	eiji bool
-)
-
 func main() {
-	// parse flag & args
-	flag.BoolVar(&eiji, "eiji", false, "Search Japanese-English dictionary on Weblio.")
-	flag.BoolVar(&eiji, "e", false, "Alias for --eiji")
-	flag.Parse()
-
-	if len(flag.Args()) != 1 {
-		fmt.Println("Invalid arguments!")
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
 
-	word := flag.Args()[0]
+func run(args []string, stdout, stderr io.Writer) error {
+	return runWithDeps(args, stdout, stderr, getWeblioDict, getWeblioEijiDict)
+}
 
-	if eiji {
-		getWeblioEijiDict(word)
-	} else {
-		getWeblioDict(word)
+type dictFunc func(word string, out io.Writer) error
+
+func runWithDeps(args []string, stdout, stderr io.Writer, dict, eijiDict dictFunc) error {
+	fs := flag.NewFlagSet("dicto", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	eiji := fs.Bool("eiji", false, "Search Japanese-English dictionary on Weblio.")
+	fs.BoolVar(eiji, "e", false, "Alias for --eiji")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: dicto [--eiji|-e] <word>")
 	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return errors.New("invalid arguments")
+	}
+
+	word := fs.Arg(0)
+	if *eiji {
+		return eijiDict(word, stdout)
+	}
+	return dict(word, stdout)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestRunWithDepsInvalidArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runWithDeps([]string{}, &stdout, &stderr, failIfCalled, failIfCalled)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid arguments") {
+		t.Fatalf("expected invalid arguments error, got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Usage: dicto") {
+		t.Fatalf("expected usage on stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunWithDepsEiji(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	var gotWord string
+
+	eiji := func(word string, out io.Writer) error {
+		gotWord = word
+		return nil
+	}
+
+	err := runWithDeps([]string{"-e", "hello"}, &stdout, &stderr, failIfCalled, eiji)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotWord != "hello" {
+		t.Fatalf("expected word hello, got %q", gotWord)
+	}
+}
+
+func TestRunWithDepsDefault(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	var gotWord string
+
+	dict := func(word string, out io.Writer) error {
+		gotWord = word
+		return nil
+	}
+
+	err := runWithDeps([]string{"world"}, &stdout, &stderr, dict, failIfCalled)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotWord != "world" {
+		t.Fatalf("expected word world, got %q", gotWord)
+	}
+}
+
+func failIfCalled(word string, out io.Writer) error {
+	return errors.New("unexpected call")
+}

--- a/weblio.go
+++ b/weblio.go
@@ -1,104 +1,147 @@
-/**
- * This file is for providing to get web page from weblio.jp
- */
+// This file provides helpers to fetch pages from weblio.jp.
 
 package main
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/fatih/color"
 )
 
-// getWeblioDict function prints dictionary in weblio.jp.
-// Top of discription block and wikipedia-jp discription will be print.
-func getWeblioDict(word string) {
-	var str string
+const (
+	weblioBaseURL     = "https://www.weblio.jp/content/"
+	weblioEijiBaseURL = "https://ejje.weblio.jp/content/"
+)
+
+var httpClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
+
+// getWeblioDict prints a dictionary entry from weblio.jp.
+// It prints the heading and the top dictionary/wikipedia excerpts.
+func getWeblioDict(word string, out io.Writer) error {
 	yellow := color.New(color.Bold, color.FgYellow).SprintFunc()
 
 	// get page from weblio.jp
-	url := "http://www.weblio.jp/content/" + word
-	doc, err := goquery.NewDocument(url)
-
+	doc, err := fetchDocument(context.Background(), weblioBaseURL+word)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
+	return renderWeblioDict(doc, word, out, yellow)
+}
 
-	// trim elemets
+func renderWeblioDict(doc *goquery.Document, word string, out io.Writer, yellow func(a ...any) string) error {
+	// trim elements
 	doc.Find(".NetDicHead .midashigo > span").Empty()
 
 	// print midashigo
-	str = doc.Find(".NetDicHead .midashigo").Text()
-	if str != "" {
-		fmt.Println(yellow(str))
-	} else {
-		str = word
-		fmt.Println(yellow(str))
+	head := strings.TrimSpace(doc.Find(".NetDicHead .midashigo").Text())
+	if head == "" {
+		head = word
 	}
+	fmt.Fprintln(out, yellow(head))
 
 	// print dictionary bodies
-	doc.Find("#cont .kiji .NetDicBody > div > div > div > div").Each(func(_ int, s *goquery.Selection) {
-		str = strings.TrimSpace(s.Text())
-		if str != "" {
-			fmt.Println(str)
+	doc.Find("#cont .kiji > div").Each(func(_ int, s *goquery.Selection) {
+		text := strings.TrimSpace(s.Text())
+		if text != "" {
+			fmt.Fprintln(out, text)
 		}
 	})
 	// print Wikipedia-ja text
-	str = strings.TrimSpace(doc.Find(".kiji .Wkpja .WkpjaTs").Next().Text())
-	if str != "" {
-		fmt.Println(str)
+	wikipedia := strings.TrimSpace(doc.Find(".kiji .Wkpja .WkpjaTs").Next().Text())
+	if wikipedia != "" {
+		fmt.Fprintln(out, wikipedia)
 	}
+	return nil
 }
 
-// getWeblioEijiDict function prints dictionary in ejje.weblio.jp.
-// summary and example writing will be print.
-func getWeblioEijiDict(word string) {
-	var str string
+// getWeblioEijiDict prints a dictionary entry from ejje.weblio.jp.
+// It prints the summary and example sentences.
+func getWeblioEijiDict(word string, out io.Writer) error {
 	green := color.New(color.Bold, color.FgGreen).SprintFunc()
 	yellow := color.New(color.FgYellow).SprintFunc()
 	bold := color.New(color.Bold).SprintFunc()
 
 	// get page from ejje.weblio.jp
-	url := "http://ejje.weblio.jp/content/" + word
-	doc, _ := goquery.NewDocument(url)
-
-	// print query
-	str = doc.Find("#h1Query").Text()
-	if str != "" {
-		fmt.Println(green(str))
-	} else {
-		str = word
-		fmt.Println(green(str))
+	doc, err := fetchDocument(context.Background(), weblioEijiBaseURL+word)
+	if err != nil {
+		return err
 	}
+	return renderWeblioEijiDict(doc, word, out, green, yellow, bold)
+}
+
+func renderWeblioEijiDict(
+	doc *goquery.Document,
+	word string,
+	out io.Writer,
+	green func(a ...any) string,
+	yellow func(a ...any) string,
+	bold func(a ...any) string,
+) error {
+	// print query
+	query := strings.TrimSpace(doc.Find("#h1Query").Text())
+	if query == "" {
+		query = word
+	}
+	fmt.Fprintln(out, green(query))
 
 	// print summary
-	summary := doc.Find(".summaryM table tbody tr td.content-explanation").Text()
-	fmt.Println(summary)
+	summary := strings.TrimSpace(doc.Find(".summaryM table tbody tr td.content-explanation").Text())
+	fmt.Fprintln(out, summary)
 
 	// print example documents
-	fmt.Print(bold("\n[Examples]\n"))
+	fmt.Fprint(out, bold("\n[Examples]\n"))
 	doc.Find(".qotC").Each(func(_ int, s *goquery.Selection) {
 		s.Find(".qotCE > span").Empty()
 		s.Find(".qotCJE > span").Empty()
 		s.Find(".qotCJJ > span").Empty()
-		exampleHead := s.Find(".qotCE").Text()
-		exampleTail := s.Find(".qotCJ").Text()
+		exampleHead := strings.TrimSpace(s.Find(".qotCE").Text())
+		exampleTail := strings.TrimSpace(s.Find(".qotCJ").Text())
 		if exampleHead == "" {
-			exampleHead = s.Find(".qotCJE").Text()
-			exampleTail = s.Find(".qotCJJ").Text()
+			exampleHead = strings.TrimSpace(s.Find(".qotCJE").Text())
+			exampleTail = strings.TrimSpace(s.Find(".qotCJJ").Text())
 		}
 		if exampleHead != "" {
-			fmt.Println(yellow(exampleHead))
-			fmt.Println(exampleTail)
+			fmt.Fprintln(out, yellow(exampleHead))
+			fmt.Fprintln(out, exampleTail)
 		}
 	})
 
 	// print more link
 	moreExample, _ := doc.Find(".hlt_SNTCE .kiji > a").Attr("href")
 	ul := color.New(color.Underline).SprintFunc()
-	fmt.Println("\n", ul(moreExample))
-	fmt.Println("")
+	fmt.Fprintln(out, "\n", ul(moreExample))
+	fmt.Fprintln(out, "")
+	return nil
+}
+
+func fetchDocument(ctx context.Context, url string) (*goquery.Document, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("failed to close response body: %v", closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+
+	return goquery.NewDocumentFromReader(resp.Body)
 }

--- a/weblio.go
+++ b/weblio.go
@@ -94,7 +94,7 @@ func renderWeblioEijiDict(
 	fmt.Fprintln(out, green(query))
 
 	// print summary
-	summary := strings.TrimSpace(doc.Find(".summaryM table tbody tr td.content-explanation").Text())
+	summary := strings.TrimSpace(doc.Find(".summaryM p .content-explanation").Text())
 	fmt.Fprintln(out, summary)
 
 	// print example documents

--- a/weblio_test.go
+++ b/weblio_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/fatih/color"
+)
+
+func TestRenderWeblioDict(t *testing.T) {
+	doc := mustDocument(t, weblioDictHTML)
+	var out bytes.Buffer
+
+	if err := renderWeblioDict(doc, "fallback", &out, fmt.Sprint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	wantLines := []string{"Head", "Meaning 1", "Wiki text"}
+
+	if len(gotLines) != len(wantLines) {
+		t.Fatalf("expected %d lines, got %d: %q", len(wantLines), len(gotLines), gotLines)
+	}
+	for i, want := range wantLines {
+		if gotLines[i] != want {
+			t.Fatalf("line %d: expected %q, got %q", i+1, want, gotLines[i])
+		}
+	}
+}
+
+func TestRenderWeblioDictFallbackHeading(t *testing.T) {
+	doc := mustDocument(t, weblioDictNoHeadHTML)
+	var out bytes.Buffer
+
+	if err := renderWeblioDict(doc, "fallback", &out, fmt.Sprint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if gotLines[0] != "fallback" {
+		t.Fatalf("expected fallback heading, got %q", gotLines[0])
+	}
+}
+
+func TestRenderWeblioEijiDict(t *testing.T) {
+	origNoColor := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = origNoColor })
+
+	doc := mustDocument(t, weblioEijiHTML)
+	var out bytes.Buffer
+
+	if err := renderWeblioEijiDict(doc, "fallback", &out, fmt.Sprint, fmt.Sprint, fmt.Sprint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := out.String()
+	assertInOrder(t, got, []string{
+		"Query",
+		"Summary",
+		"[Examples]",
+		"Example head 1",
+		"Example tail 1",
+		"Example head 2",
+		"Example tail 2",
+		"https://example.com/more",
+	})
+}
+
+func mustDocument(t *testing.T, html string) *goquery.Document {
+	t.Helper()
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("failed to parse html: %v", err)
+	}
+	return doc
+}
+
+func assertInOrder(t *testing.T, s string, parts []string) {
+	t.Helper()
+
+	idx := 0
+	for _, part := range parts {
+		pos := strings.Index(s[idx:], part)
+		if pos < 0 {
+			t.Fatalf("missing %q in output: %q", part, s)
+		}
+		idx += pos + len(part)
+	}
+}
+
+const weblioDictHTML = `
+<html><body>
+  <div class="NetDicHead"><div class="midashigo"><span>ignore</span> Head </div></div>
+  <div id="cont">
+    <div class="kiji">
+      <div class="NetDicBody"><div><div><div><div> Meaning 1 </div></div></div></div></div>
+    </div>
+  </div>
+  <div class="kiji"><div class="Wkpja"><div class="WkpjaTs">Title</div><div> Wiki text </div></div></div>
+</body></html>
+`
+
+const weblioDictNoHeadHTML = `
+<html><body>
+  <div class="NetDicHead"><div class="midashigo"><span>ignore</span> </div></div>
+  <div id="cont">
+    <div class="kiji">
+      <div class="NetDicBody"><div><div><div><div> Meaning 1 </div></div></div></div></div>
+    </div>
+  </div>
+</body></html>
+`
+
+const weblioEijiHTML = `
+<html><body>
+  <div id="h1Query">Query</div>
+  <div class="summaryM">
+    <table><tbody><tr><td class="content-explanation"> Summary </td></tr></tbody></table>
+  </div>
+  <div class="qotC">
+    <div class="qotCE"><span>rm</span> Example head 1 </div>
+    <div class="qotCJ"> Example tail 1 </div>
+  </div>
+  <div class="qotC">
+    <div class="qotCJE"><span>rm</span> Example head 2 </div>
+    <div class="qotCJJ"> Example tail 2 </div>
+  </div>
+  <div class="hlt_SNTCE"><div class="kiji"><a href="https://example.com/more">more</a></div></div>
+</body></html>
+`

--- a/weblio_test.go
+++ b/weblio_test.go
@@ -120,7 +120,7 @@ const weblioEijiHTML = `
 <html><body>
   <div id="h1Query">Query</div>
   <div class="summaryM">
-    <table><tbody><tr><td class="content-explanation"> Summary </td></tr></tbody></table>
+    <p><span class="content-explanation"> Summary </span></p>
   </div>
   <div class="qotC">
     <div class="qotCE"><span>rm</span> Example head 1 </div>


### PR DESCRIPTION
## Summary
- Align go.mod Go version to 1.25.5
- Refactor CLI and Weblio fetching for clearer error handling and testability
- Update Weblio summary selector for HTML changes
- Add unit tests for CLI flow and Weblio renderers

## Testing
- go test ./...

## Checklist
- [x] Tests added or updated
- [x] gofmt
- [x] All tests pass